### PR TITLE
solr8 image with ursus and sinai data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM solr:8.11.1
 
-COPY --from=uclalibrary/solr-ursus:2023-07-11 /var/solr/data /var/solr/data
+COPY --from=uclalibrary/solr-ursus:2023-10-13 /var/solr/data /var/solr/data

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ TODO: Move this function to a subcommand of solr_tools.py
 
 ### Commit and push to dockerhub
 ```
-docker commit docker-solr-ursus_solr_1 uclalibrary/solr-ursus:[YYYY-MM-DD]
+docker commit calursus-solr-solr-1 uclalibrary/solr-ursus:[YYYY-MM-DD]
 docker push uclalibrary/solr-ursus:[YYYY-MM-DD]
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,10 @@ services:
     build: .
     image: uclalibrary/solr-ursus:solr8
     ports:
-      - "127.0.0.1:7983:8983"
+      - "127.0.0.1:8983:8983"
+
+  solr7:
+    build: .
+    image: uclalibrary/solr-ursus:2021-12-14
+    ports:
+      - "127.0.0.1:8984:8983"


### PR DESCRIPTION
Built a new base image, with ursus and sinai cores populated by cloning the old solr7 data, and pushed to dockerhub with the tag uclalibrary/solr-ursus:2023-10-13. This PR copies data from that image for subsequent solr8 builts.