### PR TITLE
DLSR-5 use solr.ICUCollationField for unicode-aware, alphanumeric sort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: Run CI Suite
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: docker-compose run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,18 @@ name: Run CI Suite
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - master
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - master
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: docker-compose run test
+      - uses: docker/setup-compose-action@v2
+      - run: docker compose run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # editor stuff
 settings.json
 .DS_Store
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
 FROM solr:8.11
 
+RUN mkdir $SOLR_HOME/lib 
+RUN cp /opt/solr/dist/solr-analysis-extras-*.jar $SOLR_HOME/lib/ 
+RUN cp /opt/solr/contrib/analysis-extras/**/*.jar $SOLR_HOME/lib/
+
+ENV SOLR_MODULES=analysis-extras
 ADD --chown=solr:solr ursus /var/solr/data/ursus

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,3 @@
 FROM solr:8.11
 
-RUN mkdir $SOLR_HOME/lib 
-RUN cp /opt/solr/dist/solr-analysis-extras-*.jar $SOLR_HOME/lib/ 
-RUN cp /opt/solr/contrib/analysis-extras/**/*.jar $SOLR_HOME/lib/
-
-ENV SOLR_MODULES=analysis-extras
 ADD --chown=solr:solr ursus /var/solr/data/ursus

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM python:3.14
+
+COPY ./requirements.txt /calursus-solr/requirements.txt
+RUN pip install -r /calursus-solr/requirements.txt
+
+WORKDIR /calursus-solr
+COPY . /calursus-solr/
+
+CMD [ "python", "-m", "unittest" ]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 Solr config for the [UCLA Digital Library](https://digital.library.ucla.edu) ([github](https://github.com/uclalibrary/ursus)) and [Sinai Manuscripts Digital Library](https://sinaimanuscripts.library.ucla.edu) ([github](https://github.com/uclalibrary/sinaimanuscripts)) websites.
 
 Includes Dockerfile and github actions workflow to build an image for local development.
+
+## Running tests
+
+Tests are written in python and can be run with a docker-compose one-liner:
+```
+docker-compose run --renew-anon-volumes test
+```
+
+## Notes
+
+- There might be an issue with old config persisting on anonymous docker volumes, preventing updates from taking effect even after the docker image is rebuilt. (Or there might not, I haven't confirmed this.) Docker includes a flag that sounds like it will prevent this: `docker-compose up --detach --renew-anon-volumes`, and volumes can always be destroyed with `docker-compose down -v`
+

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ docker-compose run --renew-anon-volumes test
 
 ## Notes
 
-- There might be an issue with old config persisting on anonymous docker volumes, preventing updates from taking effect even after the docker image is rebuilt. (Or there might not, I haven't confirmed this.) Docker includes a flag that sounds like it will prevent this: `docker-compose up --detach --renew-anon-volumes`, and volumes can always be destroyed with `docker-compose down -v`
+- There might be an issue with old config persisting on anonymous docker volumes, preventing updates from taking effect even after the docker image is rebuilt. (Or there might not, I haven't confirmed this.) Docker includes a flag that sounds like it will prevent this, e.g. `docker-compose up --detach --renew-anon-volumes`, and volumes can always be destroyed with `docker-compose down -v`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+
+  solr:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    ports:
+      - '127.0.0.1:8983:8983'
+
+  solr_test:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    ports:
+      - '127.0.0.1:8985:8983'
+  
+  test:
+    depends_on:
+      - solr_test
+    build:
+      context: .
+      dockerfile: ./Dockerfile.test
+    environment:
+      - SOLR_TEST_URL=http://solr_test:8983/solr/ursus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,19 @@ services:
       dockerfile: ./Dockerfile
     ports:
       - '127.0.0.1:8985:8983'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8983/solr/admin/info/system"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 2s
   
   test:
     depends_on:
-      - solr_test
+      solr_test:
+        condition: service_healthy
     build:
       context: .
       dockerfile: ./Dockerfile.test
     environment:
-      - SOLR_TEST_URL=http://solr_test:8985/solr/ursus
+      - SOLR_TEST_URL=http://solr_test:8983/solr/ursus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,4 @@ services:
       context: .
       dockerfile: ./Dockerfile.test
     environment:
-      - SOLR_TEST_URL=http://solr_test:8983/solr/ursus
+      - SOLR_TEST_URL=http://solr_test:8985/solr/ursus

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.33.1
+types_requests>=2.33.0

--- a/test.py
+++ b/test.py
@@ -4,26 +4,25 @@ from unittest import TestCase
 
 import requests
 
-SOLR_URL = os.getenv("SOLR_TEST_URL")
+SOLR_URL = os.getenv("SOLR_TEST_URL", "http://localhost:8985/solr/ursus")
 
 
 class TestSort(TestCase):
-    # def setUp(self):
-    #     requests.post(
-    #         f"{SOLR_URL}/update?commit=true",
-    #         json={"delete": {"query": "*:*"}},
-    #         headers={"Content-Type": "application/json"},
-    #     )
+    def setUp(self):
+        requests.post(
+            f"{SOLR_URL}/update?commit=true",
+            json={"delete": {"query": "*:*"}},
+            headers={"Content-Type": "application/json"},
+        )
 
-    # def tearDown(self):
-    #     requests.post(
-    #         f"{SOLR_URL}/update?commit=true",
-    #         json={"delete": {"query": "*:*"}},
-    #         headers={"Content-Type": "application/json"},
-    #     )
+    def tearDown(self):
+        requests.post(
+            f"{SOLR_URL}/update?commit=true",
+            json={"delete": {"query": "*:*"}},
+            headers={"Content-Type": "application/json"},
+        )
 
     def test_sorts_non_latin(self):
-        print("HIIIIII")
         docs = [
             {"id": "1", "title_tsort": "x"},
             {"id": "2", "title_tsort": "y"},

--- a/test.py
+++ b/test.py
@@ -88,3 +88,35 @@ class TestSort(TestCase):
         )
         order_asc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
         assert order_asc == ["3", "2", "1"]
+
+    def test_ignores_punctuation(self):
+        docs = [
+            {"id": "1", "title_tsort": "a"},
+            {"id": "2", "title_tsort": "'''b"},
+            {"id": "3", "title_tsort": "c"},
+        ]
+        shuffle(docs)
+
+        # Index documents
+        requests.post(
+            f"{SOLR_URL}/update?commit=true",
+            json=docs,
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Query documents, A–Z
+        response_asc = requests.get(
+            f"{SOLR_URL}/select",
+            params={"q": "*:*", "sort": "title_tsort asc"},
+        )
+
+        order_asc = [doc["id"] for doc in response_asc.json()["response"]["docs"]]
+        self.assertEqual(order_asc, ["1", "2", "3"])
+
+        # Query documents, Z–A
+        response_desc = requests.get(
+            f"{SOLR_URL}/select",
+            params={"q": "*:*", "sort": "title_tsort desc"},
+        )
+        order_asc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
+        assert order_asc == ["3", "2", "1"]

--- a/test.py
+++ b/test.py
@@ -8,28 +8,29 @@ SOLR_URL = os.getenv("SOLR_TEST_URL")
 
 
 class TestSort(TestCase):
-    def setUp(self):
-        requests.post(
-            f"{SOLR_URL}/update?commit=true",
-            json={"delete": {"query": "*:*"}},
-            headers={"Content-Type": "application/json"},
-        )
+    # def setUp(self):
+    #     requests.post(
+    #         f"{SOLR_URL}/update?commit=true",
+    #         json={"delete": {"query": "*:*"}},
+    #         headers={"Content-Type": "application/json"},
+    #     )
 
-    def tearDown(self):
-        requests.post(
-            f"{SOLR_URL}/update?commit=true",
-            json={"delete": {"query": "*:*"}},
-            headers={"Content-Type": "application/json"},
-        )
+    # def tearDown(self):
+    #     requests.post(
+    #         f"{SOLR_URL}/update?commit=true",
+    #         json={"delete": {"query": "*:*"}},
+    #         headers={"Content-Type": "application/json"},
+    #     )
 
     def test_sorts_non_latin(self):
+        print("HIIIIII")
         docs = [
-            {"id": "1", "title_alpha_numeric_ssort": "x"},
-            {"id": "2", "title_alpha_numeric_ssort": "y"},
-            {"id": "3", "title_alpha_numeric_ssort": "z"},
-            {"id": "4", "title_alpha_numeric_ssort": "あ(a)"},
-            {"id": "5", "title_alpha_numeric_ssort": "い(i)"},
-            {"id": "6", "title_alpha_numeric_ssort": "う(u)"},
+            {"id": "1", "title_tsort": "x"},
+            {"id": "2", "title_tsort": "y"},
+            {"id": "3", "title_tsort": "z"},
+            {"id": "4", "title_tsort": "あ(a)"},
+            {"id": "5", "title_tsort": "い(i)"},
+            {"id": "6", "title_tsort": "う(u)"},
         ]
         shuffle(docs)
 
@@ -43,7 +44,7 @@ class TestSort(TestCase):
         # Query documents, A–Z
         response_asc = requests.get(
             f"{SOLR_URL}/select",
-            params={"q": "*:*", "sort": "title_alpha_numeric_ssort asc"},
+            params={"q": "*:*", "sort": "title_tsort asc"},
         )
 
         order_asc = [doc["id"] for doc in response_asc.json()["response"]["docs"]]
@@ -52,16 +53,16 @@ class TestSort(TestCase):
         # Query documents, Z–A
         response_desc = requests.get(
             f"{SOLR_URL}/select",
-            params={"q": "*:*", "sort": "title_alpha_numeric_ssort desc"},
+            params={"q": "*:*", "sort": "title_tsort desc"},
         )
         order_asc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
         assert order_asc == ["6", "5", "4", "3", "2", "1"]
 
     def test_sorts_numeric(self):
         docs = [
-            {"id": "1", "title_alpha_numeric_ssort": "thing 1"},
-            {"id": "2", "title_alpha_numeric_ssort": "thing 9"},
-            {"id": "3", "title_alpha_numeric_ssort": "thing 10"},
+            {"id": "1", "title_tsort": "thing 1"},
+            {"id": "2", "title_tsort": "thing 9"},
+            {"id": "3", "title_tsort": "thing 10"},
         ]
         shuffle(docs)
 
@@ -75,7 +76,7 @@ class TestSort(TestCase):
         # Query documents, A–Z
         response_asc = requests.get(
             f"{SOLR_URL}/select",
-            params={"q": "*:*", "sort": "title_alpha_numeric_ssort asc"},
+            params={"q": "*:*", "sort": "title_tsort asc"},
         )
 
         order_asc = [doc["id"] for doc in response_asc.json()["response"]["docs"]]
@@ -84,7 +85,7 @@ class TestSort(TestCase):
         # Query documents, Z–A
         response_desc = requests.get(
             f"{SOLR_URL}/select",
-            params={"q": "*:*", "sort": "title_alpha_numeric_ssort desc"},
+            params={"q": "*:*", "sort": "title_tsort desc"},
         )
         order_asc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
         assert order_asc == ["3", "2", "1"]

--- a/test.py
+++ b/test.py
@@ -54,8 +54,8 @@ class TestSort(TestCase):
             f"{SOLR_URL}/select",
             params={"q": "*:*", "sort": "title_tsort desc"},
         )
-        order_asc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
-        assert order_asc == ["6", "5", "4", "3", "2", "1"]
+        order_desc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
+        assert order_desc == ["6", "5", "4", "3", "2", "1"]
 
     def test_sorts_numeric(self):
         docs = [
@@ -86,8 +86,8 @@ class TestSort(TestCase):
             f"{SOLR_URL}/select",
             params={"q": "*:*", "sort": "title_tsort desc"},
         )
-        order_asc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
-        assert order_asc == ["3", "2", "1"]
+        order_desc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
+        assert order_desc == ["3", "2", "1"]
 
     def test_ignores_punctuation(self):
         docs = [
@@ -118,5 +118,5 @@ class TestSort(TestCase):
             f"{SOLR_URL}/select",
             params={"q": "*:*", "sort": "title_tsort desc"},
         )
-        order_asc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
-        assert order_asc == ["3", "2", "1"]
+        order_desc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
+        assert order_desc == ["3", "2", "1"]

--- a/test.py
+++ b/test.py
@@ -1,0 +1,90 @@
+import os
+from random import shuffle
+from unittest import TestCase
+
+import requests
+
+SOLR_URL = os.getenv("SOLR_TEST_URL")
+
+
+class TestSort(TestCase):
+    def setUp(self):
+        requests.post(
+            f"{SOLR_URL}/update?commit=true",
+            json={"delete": {"query": "*:*"}},
+            headers={"Content-Type": "application/json"},
+        )
+
+    def tearDown(self):
+        requests.post(
+            f"{SOLR_URL}/update?commit=true",
+            json={"delete": {"query": "*:*"}},
+            headers={"Content-Type": "application/json"},
+        )
+
+    def test_sorts_non_latin(self):
+        docs = [
+            {"id": "1", "title_alpha_numeric_ssort": "x"},
+            {"id": "2", "title_alpha_numeric_ssort": "y"},
+            {"id": "3", "title_alpha_numeric_ssort": "z"},
+            {"id": "4", "title_alpha_numeric_ssort": "あ(a)"},
+            {"id": "5", "title_alpha_numeric_ssort": "い(i)"},
+            {"id": "6", "title_alpha_numeric_ssort": "う(u)"},
+        ]
+        shuffle(docs)
+
+        # Index documents
+        requests.post(
+            f"{SOLR_URL}/update?commit=true",
+            json=docs,
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Query documents, A–Z
+        response_asc = requests.get(
+            f"{SOLR_URL}/select",
+            params={"q": "*:*", "sort": "title_alpha_numeric_ssort asc"},
+        )
+
+        order_asc = [doc["id"] for doc in response_asc.json()["response"]["docs"]]
+        self.assertEqual(order_asc, ["1", "2", "3", "4", "5", "6"])
+
+        # Query documents, Z–A
+        response_desc = requests.get(
+            f"{SOLR_URL}/select",
+            params={"q": "*:*", "sort": "title_alpha_numeric_ssort desc"},
+        )
+        order_asc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
+        assert order_asc == ["6", "5", "4", "3", "2", "1"]
+
+    def test_sorts_numeric(self):
+        docs = [
+            {"id": "1", "title_alpha_numeric_ssort": "thing 1"},
+            {"id": "2", "title_alpha_numeric_ssort": "thing 9"},
+            {"id": "3", "title_alpha_numeric_ssort": "thing 10"},
+        ]
+        shuffle(docs)
+
+        # Index documents
+        requests.post(
+            f"{SOLR_URL}/update?commit=true",
+            json=docs,
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Query documents, A–Z
+        response_asc = requests.get(
+            f"{SOLR_URL}/select",
+            params={"q": "*:*", "sort": "title_alpha_numeric_ssort asc"},
+        )
+
+        order_asc = [doc["id"] for doc in response_asc.json()["response"]["docs"]]
+        self.assertEqual(order_asc, ["1", "2", "3"])
+
+        # Query documents, Z–A
+        response_desc = requests.get(
+            f"{SOLR_URL}/select",
+            params={"q": "*:*", "sort": "title_alpha_numeric_ssort desc"},
+        )
+        order_asc = [doc["id"] for doc in response_desc.json()["response"]["docs"]]
+        assert order_asc == ["3", "2", "1"]

--- a/ursus/conf/schema.xml
+++ b/ursus/conf/schema.xml
@@ -480,6 +480,7 @@
     class="solr.ICUCollationField"
     locale="en-US"
     numeric="true"
+    alternate="shifted"
   />
 
   <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">

--- a/ursus/conf/schema.xml
+++ b/ursus/conf/schema.xml
@@ -120,7 +120,7 @@
   <field name="lat" type="pdouble" stored="true" indexed="true" multiValued="false" />
   <field name="lng" type="pdouble" stored="true" indexed="true" multiValued="false" />
 
-  <field name="title_alpha_numeric_ssort" type="icuCollationSort" indexed="true" stored="false"
+  <field name="title_alpha_numeric_ssort" type="alphaNumericSort" indexed="true" stored="false"
     multiValued="false" />
   <field name="date_dtsort" type="pdate" indexed="true" stored="true" multiValued="false" />
   <!-- custom fields for ursus end 06/14/2022-->
@@ -226,7 +226,8 @@
   <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true" />
   <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false" />
   <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true" />
-  <dynamicField name="*_ssort" type="icuCollationSort" stored="false" indexed="true" multiValued="false" />
+  <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false" />
+  <dynamicField name="*_tsort" type="icuCollationSort" stored="false" indexed="true" multiValued="false" />
 
   <!-- integer (_i...) -->
   <dynamicField name="*_ii" type="pint" stored="false" indexed="true" multiValued="false" />
@@ -442,6 +443,37 @@
   <fieldType name="rank" class="solr.RankField" />
 
   <!-- Custom fields for ursus -->
+
+  <fieldType name="alphaNumericSort" class="solr.TextField" sortMissingLast="false" omitNorms="true">
+    <analyzer>
+      <!-- KeywordTokenizer does no actual tokenizing, so the entire
+            input string is preserved as a single token -->
+      <tokenizer class="solr.KeywordTokenizerFactory" />
+      <!-- The LowerCase TokenFilter does what you expect, which can be
+            when you want your sorting to be case insensitive -->
+      <filter class="solr.LowerCaseFilterFactory" />
+      <!-- The TrimFilter removes any leading or trailing whitespace -->
+      <filter class="solr.TrimFilterFactory" />
+      <!-- Left-pad numbers with zeroes -->
+      <filter class="solr.PatternReplaceFilterFactory" pattern="(\d+)" replacement="00000$1"
+        replace="all" />
+      <!-- Left-trim zeroes to produce 6 digit numbers -->
+      <filter class="solr.PatternReplaceFilterFactory" pattern="0*([0-9]{6,})" replacement="$1"
+        replace="all" />
+      <!-- Remove all but alphanumeric characters -->
+      <filter class="solr.PatternReplaceFilterFactory" pattern="([^a-z0-9])" replacement=""
+        replace="all" />
+    </analyzer>
+  </fieldType>
+
+  <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
+  <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+    <analyzer>
+      <tokenizer class="solr.KeywordTokenizerFactory" />
+      <filter class="solr.ICUFoldingFilterFactory" />
+      <filter class="solr.TrimFilterFactory" />
+    </analyzer>
+  </fieldtype>
 
   <fieldType 
     name="icuCollationSort"

--- a/ursus/conf/schema.xml
+++ b/ursus/conf/schema.xml
@@ -120,7 +120,7 @@
   <field name="lat" type="pdouble" stored="true" indexed="true" multiValued="false" />
   <field name="lng" type="pdouble" stored="true" indexed="true" multiValued="false" />
 
-  <field name="title_alpha_numeric_ssort" type="alphaNumericSort" indexed="true" stored="false"
+  <field name="title_alpha_numeric_ssort" type="icuCollationSort" indexed="true" stored="false"
     multiValued="false" />
   <field name="date_dtsort" type="pdate" indexed="true" stored="true" multiValued="false" />
   <!-- custom fields for ursus end 06/14/2022-->
@@ -226,7 +226,7 @@
   <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true" />
   <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false" />
   <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true" />
-  <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false" />
+  <dynamicField name="*_ssort" type="icuCollationSort" stored="false" indexed="true" multiValued="false" />
 
   <!-- integer (_i...) -->
   <dynamicField name="*_ii" type="pint" stored="false" indexed="true" multiValued="false" />
@@ -443,36 +443,13 @@
 
   <!-- Custom fields for ursus -->
 
-  <fieldType name="alphaNumericSort" class="solr.TextField" sortMissingLast="false" omitNorms="true">
-    <analyzer>
-      <!-- KeywordTokenizer does no actual tokenizing, so the entire
-            input string is preserved as a single token -->
-      <tokenizer class="solr.KeywordTokenizerFactory" />
-      <!-- The LowerCase TokenFilter does what you expect, which can be
-            when you want your sorting to be case insensitive -->
-      <filter class="solr.LowerCaseFilterFactory" />
-      <!-- The TrimFilter removes any leading or trailing whitespace -->
-      <filter class="solr.TrimFilterFactory" />
-      <!-- Left-pad numbers with zeroes -->
-      <filter class="solr.PatternReplaceFilterFactory" pattern="(\d+)" replacement="00000$1"
-        replace="all" />
-      <!-- Left-trim zeroes to produce 6 digit numbers -->
-      <filter class="solr.PatternReplaceFilterFactory" pattern="0*([0-9]{6,})" replacement="$1"
-        replace="all" />
-      <!-- Remove all but alphanumeric characters -->
-      <filter class="solr.PatternReplaceFilterFactory" pattern="([^a-z0-9])" replacement=""
-        replace="all" />
-    </analyzer>
-  </fieldType>
+  <fieldType 
+    name="icuCollationSort"
+    class="solr.ICUCollationField"
+    locale="en-US"
+    numeric="true"
+  />
 
-  <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
-  <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
-    <analyzer>
-      <tokenizer class="solr.KeywordTokenizerFactory" />
-      <filter class="solr.ICUFoldingFilterFactory" />
-      <filter class="solr.TrimFilterFactory" />
-    </analyzer>
-  </fieldtype>
   <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
     <analyzer>
       <tokenizer class="solr.KeywordTokenizerFactory" />

--- a/ursus/conf/solrconfig.xml
+++ b/ursus/conf/solrconfig.xml
@@ -78,7 +78,7 @@
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
   <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
   <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />
-    <lib dir="${solr.install.dir:/opt/solr}/dist/" regex="solr-analysis-extras-\d+\.\d+\.\d+.jar" />
+  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-analysis-extras-\d+\.\d+\.\d+.jar" />
 
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged

--- a/ursus/conf/solrconfig.xml
+++ b/ursus/conf/solrconfig.xml
@@ -78,6 +78,7 @@
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
   <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
   <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />
+    <lib dir="${solr.install.dir:/opt/solr}/dist/" regex="solr-analysis-extras-\d+\.\d+\.\d+.jar" />
 
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged


### PR DESCRIPTION
Create a new dynamic field rule, `*_tsort`, which uses ICUCollationField from solr's analysis_extras package.

This leaves existing fields unchanged for easier migration, and the 't' suffix is more appropriate to the function (indicating analysis as text rather than a basic string symbol). It leaves _ssort available for any future fields (like identifiers) we might want to sort by.